### PR TITLE
fix: restore shell environment resolution on startup

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -32,6 +32,8 @@ jobs:
       run: npm install
     - name: Run prebuild script
       run: npm run prebuild-linux
+    - name: Test application startup dependencies
+      run: npm --prefix prebuild-src test
     - name: Build for x64
       run: ./node_modules/.bin/electron-builder build -l --x64
       env:

--- a/src/_boot.js
+++ b/src/_boot.js
@@ -40,6 +40,7 @@ const path = require("path");
 const url = require("url");
 const fs = require("fs");
 const which = require("which");
+const getShellEnv = require("./shell-env.js");
 const Terminal = require("./classes/terminal.class.js").Terminal;
 
 ipc.on("log", (e, type, content) => {
@@ -279,7 +280,7 @@ app.on('ready', async () => {
     if (!require("fs").existsSync(settings.cwd)) throw new Error("Configured cwd path does not exist.");
 
     // See #366
-    let cleanEnv = await require("shell-env").shellEnv(settings.shell).catch(e => { throw e; });
+    let cleanEnv = await getShellEnv(settings.shell).catch(e => { throw e; });
 
     Object.assign(cleanEnv, {
         TERM: "xterm-256color",

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "_boot.js",
   "scripts": {
-    "test": "node --test test/*.test.js"
+    "test": "node --test"
   },
   "repository": {
     "type": "git",

--- a/src/package.json
+++ b/src/package.json
@@ -12,6 +12,9 @@
     "terminal"
   ],
   "main": "_boot.js",
+  "scripts": {
+    "test": "node --test test/*.test.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/andreas-hartmann/xdex-ui"

--- a/src/shell-env.js
+++ b/src/shell-env.js
@@ -1,3 +1,1 @@
-const shellEnv = require("shell-env");
-
-module.exports = shell => shellEnv(shell);
+module.exports = require("shell-env");

--- a/src/shell-env.js
+++ b/src/shell-env.js
@@ -1,0 +1,3 @@
+const shellEnv = require("shell-env");
+
+module.exports = shell => shellEnv(shell);

--- a/src/test/shellEnv.test.js
+++ b/src/test/shellEnv.test.js
@@ -4,8 +4,11 @@ const test = require("node:test");
 const getShellEnv = require("../shell-env.js");
 
 test("resolves the environment for a shell", async () => {
-    const env = await getShellEnv(process.env.SHELL || "/bin/sh");
+    const shell = process.platform === "win32"
+        ? process.env.ComSpec
+        : process.env.SHELL || "/bin/sh";
+    const env = await getShellEnv(shell);
 
     assert.equal(typeof env, "object");
-    assert.ok(env.PATH);
+    assert.ok(env.PATH || env.Path);
 });

--- a/src/test/shellEnv.test.js
+++ b/src/test/shellEnv.test.js
@@ -1,0 +1,11 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const getShellEnv = require("../shell-env.js");
+
+test("resolves the environment for a shell", async () => {
+    const env = await getShellEnv(process.env.SHELL || "/bin/sh");
+
+    assert.equal(typeof env, "object");
+    assert.ok(env.PATH);
+});


### PR DESCRIPTION
## Summary

- restore environment resolution using the callable `shell-env` export
- keep the startup dependency behind a small, testable helper
- run the regression test in the Linux build job

## Problem

`shell-env` is pinned to version 3.0.1, whose CommonJS export is a function with a `sync` property. It does not expose a `shellEnv` method.

The current startup path calls `require("shell-env").shellEnv(settings.shell)`, so startup fails after resolving the configured shell because `shellEnv` is undefined.

This restores the API usage that existed before commit 4aa9bdda03be854ef8a8ab6402b7acf9d65a8920 and adds a regression test around the environment resolver.

## Testing

- `npm --prefix src test`
- syntax-checked all non-vendored JavaScript files with `node --check`
- `git diff --check`
